### PR TITLE
fix Debian build after file was renamed

### DIFF
--- a/debian/docs
+++ b/debian/docs
@@ -1,1 +1,1 @@
-README
+README.md


### PR DESCRIPTION
README file was renamed to README.md but change wasn't reflected in Debian packaging